### PR TITLE
MAINT: Improve branching logic

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,0 +1,16 @@
+doc-warnings : true
+test-warnings : false
+strictness: medium
+max-line-length : 80
+autodetect: true
+ignore-paths:
+   - docs
+   - lightpath/__init__.py
+ignore-patterns:
+    - versioneer.py
+    - lightpath/_version.py
+python-targets:
+    - 3
+pylint:
+    disable:
+        - protected-access

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ after_success:
   - codecov
   - |
     if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $CONDA_UPLOAD_TOKEN_TAG != '' ]]; then
-      conda build . -c defaults -c conda-forge -c skywalker-dev -c lightsource2-tag -c paulscherrerinstitute --token $CONDA_UPLOAD_TOKEN_TAG --python $TRAVIS_PYTHON_VERSION
+      conda build . -c defaults -c conda-forge -c skywalker-dev -c lightsource2-tag --token $CONDA_UPLOAD_TOKEN_TAG --python $TRAVIS_PYTHON_VERSION
     fi
   - |
     if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
-      conda build . -c defaults -c conda-forge -c skywalker-dev -c lightsource2-tag -c paulscherrerinstitute --token $CONDA_UPLOAD_TOKEN_DEV --python $TRAVIS_PYTHON_VERSION
+      conda build . -c defaults -c conda-forge -c skywalker-dev -c lightsource2-tag --token $CONDA_UPLOAD_TOKEN_DEV --python $TRAVIS_PYTHON_VERSION
     fi

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ LCLS Lightpath
 .. image:: https://codecov.io/github/slaclab/lightpath/coverage.svg?branch=master
     :target: https://codecov.io/gh/slaclab/lightpath?branch=master
 
+.. image:: https://landscape.io/github/slaclab/lightpath/master/landscape.svg?style=flat
+    :target: https://landscape.io/github/slaclab/lightpath/master
+
 Python module for control of LCLS beamlines
 
 By abstracting individual devices into larger collections of paths, operators
@@ -21,10 +24,10 @@ Install the most recent tagged build:
 
 .. code::
 
-  conda install lightpath -c skywalker-tag -c lightsource2-tag -c conda-forge -c paulscherrerinstitute
+  conda install lightpath -c skywalker-tag -c lightsource2-tag -c conda-forge
 
 Install the most recent development build:
 
 .. code::
 
-  conda install lightpath -c skywalker-dev -c lightsource2-tag -c conda-forge -c paulscherrerinstitute
+  conda install lightpath -c skywalker-dev -c lightsource2-tag -c conda-forge

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,6 @@ requirements:
       - ophyd ==0.6.1
       - pyqt >=5 
       - numpy
-      - pcaspy
       - prettytable
 
 test:

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -1,5 +1,8 @@
 Introduction
 ************
+
+Device Manipulation
+^^^^^^^^^^^^^^^^^^^
 The lightpath abstracts control of multiple devices into a single beampath
 object. Actual device instantiation should be handled else where the lightpath
 just assumes that you give it a list of devices that match the
@@ -73,6 +76,27 @@ you actually want to remove.
    path.clear(passive=True)
    
    path.incident_devices
+
+
+Branching Logic
+^^^^^^^^^^^^^^^
+The most complicated logic within the lightpath is the determination of the
+state of optics which control pointing between different LCLS hutches.
+Obviously, whether the pointing is accurately delivered to each hutch is beyond
+the scope of this module, the lightpath does try to generally determine where
+beam is possible by looking at higher level EPICS variables. The device capable
+of steering beam between forks in the path can be found with
+:attr:`.BeamPath.branches`. Each should implement; ``branches``, all possible
+beamline destinations for the optic, and ``destination``, a list of current
+beamlines the device could be sending beam along. When the :class:`.BeamPath`
+object finds an incontinuous beamline, it checks a list of upstream optics to
+make sure that they all agree upon the destination. For instance, to deliver
+beam down the **MFX** line, both ``XRT M1`` and ``XRT M2`` must have **MFX** in
+their list of destinations. After this split, these optics are ignored so that
+each branching device only has to list the possible destinations that come
+immediattely after it. For example, the **XPP** LODCM should not have to report
+that it is ready to deliver beam to every possible **FEH** destination, only
+whether it is inserted for XPP operations or out of the **HXR** beampath. 
 
 MPS Information
 ^^^^^^^^^^^^^^^

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -142,9 +142,11 @@ class Crystal(Valve):
     """
     Generic branching device
     """
-    def __init__(self, name, z, beamline, branch):
+    def __init__(self, name, z, beamline, states):
         super().__init__(name, z, beamline)
-        self.branches = [self.beamline, branch]
+        self.states = states
+        self.branches = [dest for state in self.states
+                              for dest  in state]
         self.mps      = None
 
     @property
@@ -153,10 +155,10 @@ class Crystal(Valve):
         Return current beam destination
         """
         if self.inserted:
-            return [self.branches[1]]
+            return self.states[1]
 
         elif self.removed:
-            return [self.beamline]
+            return self.states[0]
 
         else:
             return self.branches
@@ -206,7 +208,8 @@ def path():
                Valve('one',      z=2.,  beamline='TST'),
                Stopper('two',    z=9.,  beamline='TST'),
                Valve('three',    z=15., beamline='TST'),
-               Crystal('four',   z=16., beamline='TST', branch='SIM'),
+               Crystal('four',   z=16., beamline='TST',
+                                        states=[['TST'],['SIM']]),
                IPIMB('five',     z=24., beamline='TST'),
                Valve('six',      z=30., beamline='TST'),
               ]
@@ -223,7 +226,8 @@ def branch():
                Valve('one',      z=2.,  beamline='TST'),
                Stopper('two',    z=9.,  beamline='TST'),
                Valve('three',    z=15., beamline='TST'),
-               Crystal('four',   z=16., beamline='TST', branch='SIM'),
+               Crystal('four',   z=16., beamline='TST',
+                                        states=[['TST'],['SIM']]),
                IPIMB('five',     z=24., beamline='SIM'),
                Valve('six',      z=30., beamline='SIM'),
               ]
@@ -239,16 +243,18 @@ def lcls():
             Valve('FEE Valve 2',   z=2.,   beamline='HXR'),
             Stopper('S2 Stopper',  z=9.,   beamline='HXR'),
             IPIMB('XRT IPM',       z=15.,  beamline='HXR'),
-            Crystal('XRT M1H',     z=16.,  beamline='HXR', branch='XCS'),
+            Crystal('XRT M1H',     z=16.,  beamline='HXR',
+                                           states=[['MEC','CXI'],['XCS']]),
             Valve('XRT Valve',     z=18.,  beamline='HXR'),
-            Crystal('XRT M2H',     z=20.,  beamline='HXR', branch='MEC'),
-            IPIMB('HXR IPM',       z=24.,  beamline='HXR'),
-            Valve('HXR Valve',     z=25.,  beamline='HXR'),
-            Stopper('S5 Stopper',  z=31.,  beamline='HXR'),
+            Crystal('XRT M2H',     z=20.,  beamline='HXR',
+                                           states=[['CXI','XCS'],['MEC']]),
+            IPIMB('HXR IPM',       z=24.,  beamline='CXI'),
+            Valve('HXR Valve',     z=25.,  beamline='CXI'),
+            Stopper('S5 Stopper',  z=31.,  beamline='CXI'),
             Stopper('S4 Stopper',  z=32.,  beamline='XCS'),
             Stopper('S6 Stopper',  z=30.,  beamline='MEC'),
             IPIMB('MEC IPM',       z=24.,  beamline='MEC'),
             Valve('MEC Valve',     z=25.,  beamline='MEC'),
-            IPIMB('XCS IPM',       z=17.,  beamline='XCS'),
+            IPIMB('XCS IPM',       z=21.,  beamline='XCS'),
             Valve('XCS Valve',     z=22.,  beamline='XCS'),
               ]

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -16,18 +16,22 @@ from lightpath import LightController
 def test_controller_paths(lcls):
     controller = LightController(*lcls)
     #See that we have all the beamlines accounted for
-    assert all(line in controller.beamlines.keys() for line in ['HXR', 'XCS', 'MEC'])
+    assert all(line in controller.beamlines.keys()
+               for line in ['CXI','HXR', 'XCS', 'MEC'])
     #We have total path lengths
-    assert len(controller.xcs.devices) == 8
-    assert len(controller.hxr.devices) == 10
+    assert len(controller.xcs.devices) == 10
+    assert len(controller.hxr.devices) == 7
+    assert len(controller.cxi.devices) == 10
     assert len(controller.mec.devices) == 10
     #Range of each path is correct
     assert controller.xcs.path[0]   == lcls[0]
     assert controller.xcs.path[-1]  == lcls[10]
     assert controller.hxr.path[0]   == lcls[0]
-    assert controller.hxr.path[-1]  == lcls[9]
+    assert controller.hxr.path[-1]  == lcls[6]
     assert controller.mec.path[0]   == lcls[0]
     assert controller.mec.path[-1]  == lcls[11]
+    assert controller.cxi.path[0]   == lcls[0]
+    assert controller.cxi.path[-1]  == lcls[9]
 
 def test_controller_device_summaries(lcls):
     controller = LightController(*lcls)
@@ -40,11 +44,11 @@ def test_controller_device_summaries(lcls):
     controller.hxr.path[0].remove()
     #Use mirrors to change destination
     controller.xcs.path[-1].insert()
-    controller.hxr.path[-1].insert()
-    assert controller.destinations == [controller.hxr.path[-1]]
+    controller.cxi.path[-1].insert()
+    assert controller.destinations == [controller.cxi.path[-1]]
     lcls[4].insert()
     assert controller.destinations == [controller.xcs.path[-1]]
-    controller.hxr.path[-1].remove()
+    controller.cxi.path[-1].remove()
     controller.xcs.path[-1].remove()
     lcls[4].remove()
 
@@ -69,9 +73,9 @@ def test_controller_device_summaries(lcls):
     lcls[0].insert()
     assert controller.tripped_devices == [lcls[0]]
     #Multiple faults
-    controller.hxr.path[8].insert()
+    controller.cxi.path[8].insert()
     assert len(controller.tripped_devices) == 2
-    controller.hxr.path[2].insert()
+    controller.cxi.path[2].insert()
     assert len(controller.tripped_devices) == 1
 
 

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -198,6 +198,35 @@ def test_faulted_devices(path):
                                     path.path[1],
                                     path.path[6]]
 
+def test_complex_branching(lcls):
+    #Upstream Optic
+    xcs = [d for d in lcls if d.beamline in ['HXR','XCS']]
+    bp  = BeamPath(*xcs)
+    #Remove all the devices
+    for d in xcs : d.remove()
+    #OffsetMirror should be blocking
+    assert bp.impediment == xcs[4]
+    #Insert OffsetMirror
+    bp.path[4].insert()
+    #Path should be cleared
+    assert bp.blocking_devices == []
+    #Downstream Optic
+    mec = [d for d in lcls if d.beamline in ['HXR','MEC']]
+    bp  = BeamPath(*mec)
+    #Remove all devices
+    for d in mec : d.remove()
+    #Path should be cleared
+    assert bp.impediment == mec[6]
+    #Insert first mirror
+    bp.path[4].insert()
+    assert bp.impediment == mec[4]
+    #Insert second mirror
+    bp.path[6].insert()
+    assert bp.impediment == mec[4]
+    #Retract first mirror
+    bp.path[4].remove()
+    assert bp.blocking_devices == []
+
 def test_tripped_devices(path):
     #No tripped devices by default
     assert path.tripped_devices == []


### PR DESCRIPTION
Closes #15 

### Branching Improvement
Prior to this commit, the branching logic in the lightpath required that the last device in every beamline be an optic. This however is not the case in actuality. In most cases involving mirrors, there are multiple devices allowed on the "shared" line after the optic but before the pointing has diverged into multiple beamlines. This update allows us to accomodate this within the lightpath as well as handle situations where pointing to different beamlines requires the coordination of multiple upstream optics i.e beam can not be delivered to MFX unless XRT M1H is removed AND XRT M2H is inserted. 


### Also
* Removed `pcaspy` from conda-recipe
* Some quick style fixes
* Add landscape cfg and badge
