### PR TITLE
MAINT: Use EPICS efficiently

### DIFF
--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -46,11 +46,11 @@ class LightController:
         #Iterate through creating complete paths 
         for bp in sorted(self.beamlines.values(),
                          key = lambda x : x.path[0].z):
-            logger.debug("Assembling complete beamline %s ...", bp.name)
+            logger.info("Assembling beamline %s ...", bp.name)
 
             #Grab branches off the beamline
             for branch in bp.branches:
-                logger.info("Found branches onto beamlines %s from %s",
+                logger.debug("Found branches onto beamlines %s from %s",
                              ', '.join(branch.branches), branch.name)
                 for dest in branch.branches:
                     if dest != bp.name:

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -464,9 +464,13 @@ class BeamPath(OphydObject):
             #Subscribe to all child devices
             for dev in self.devices:
                 #Add callback here!
-                dev.subscribe(self._device_moved,
-                              event_type=dev.SUB_STATE,
-                              run=False)
+                try:
+                    dev.subscribe(self._device_moved,
+                                  event_type=dev.SUB_STATE,
+                                  run=False)
+                except:
+                    logger.error("BeamPath is unable to subscribe to device %s",
+                                 dev.name)
             self._has_subscribed = True
         super().subscribe(cb, event_type=event_type, run=run)
 

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -76,6 +76,7 @@ class BeamPath(OphydObject):
     def __init__(self, *devices, name=None):
         super().__init__(name=name)
         self.devices = devices
+        self._has_subscribed = False
         logger.debug("Configuring path %s with %s devices",
                      name, len(self.devices))
         #Sort by position downstream to upstream
@@ -88,9 +89,6 @@ class BeamPath(OphydObject):
                                           'non-existant beamline position, '
                                           'its coordinate was not properly '
                                           'initialized', dev)
-                #Add callback here!
-                dev.subscribe(self._device_moved,
-                              run=False)
                 #Add as attribute
                 setattr(self, dev.name.replace(' ','_'), dev)
 
@@ -172,16 +170,14 @@ class BeamPath(OphydObject):
         current :attr:`.impediment` and any upstream devices that may be
         inserted but have more transmission than :attr:`.minimum_transmission`
         """
-        inserted = [d for d in self.path if d.inserted]
-        #Return an empty list instead of None
-        if not inserted:
-            return []
+        #Find device information
+        inserted   = [d for d in self.path if d.inserted]
+        impediment = self.impediment
         #No blocking devices, all inserted devices incident
-        elif not self.impediment:
+        if not impediment:
             return inserted
         #Otherwise only return upstream of the impediment
-        else:
-            return [d for d in inserted if d.z <= self.impediment.z]
+        return [d for d in inserted if d.z <= impediment.z]
 
     def show_devices(self, file=None):
         """
@@ -236,18 +232,20 @@ class BeamPath(OphydObject):
         return [device for device in self.path
                 if getattr(device, 'mps', None)
                 and device.mps.faulted
-                and not device.mps.bypassed]
+                and not (device.mps.bypassed or device.mps.veto_capable)]
 
     @property
     def impediment(self):
         """
         First blocking device along the path
         """
-        if not self.blocking_devices:
+        #Find device information
+        blocks = self.blocking_devices
+        if not blocks:
             return None
 
         else:
-            return self.blocking_devices[0]
+            return blocks[0]
 
     @property
     def cleared(self):
@@ -432,13 +430,45 @@ class BeamPath(OphydObject):
         """
         Run when a device changes state
         """
-        #Maybe this should introspect and see if beampath state changes
-        self._run_subs(sub_type = self.SUB_PTH_CHNG,
-                         device = obj)
+        #Determine whether our path has been changed
+        block = self.impediment
+        if block:
+            block = block.z
+        else:
+            block = np.inf
+        #If device is upstream of impediment
+        if obj and obj.z <= block:
+            self._run_subs(sub_type = self.SUB_PTH_CHNG,
+                             device = obj)
         #Alert that an MPS system has moved
-        if getattr(obj, 'mps', None):
+        if obj and getattr(obj, 'mps', None):
             self._run_subs(sub_type=self.SUB_MPSPATH_CHNG,
-                          device=obj)
+                           device=obj)
+
+    def subscribe(self, cb, event_type=None, run=True):
+        """
+        Subscribe to changes of the valve
+
+        Parameters
+        ----------
+        cb : callable
+            Callback to be run
+
+        event_type : str, optional
+            Type of event to run callback on
+
+        run : bool, optional
+            Run the callback immediatelly
+        """
+        if not self._has_subscribed:
+            #Subscribe to all child devices
+            for dev in self.devices:
+                #Add callback here!
+                dev.subscribe(self._device_moved,
+                              event_type=dev.SUB_STATE,
+                              run=False)
+            self._has_subscribed = True
+        super().subscribe(cb, event_type=event_type, run=run)
 
     def _repr_info(self):
         yield('range',   self.range)

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -60,8 +60,8 @@ class Valve(Device):
     """
     _transmission = 0.0
     _veto         = False
-    SUB_DEV_CH    = 'device_state_changed'
-    _default_sub  = SUB_DEV_CH
+    SUB_STATE    = 'sub_state_changed'
+    _default_sub  = SUB_STATE
 
     def __init__(self, name, z, beamline):
         super().__init__(name)

--- a/lightpath/tests/test_widgets.py
+++ b/lightpath/tests/test_widgets.py
@@ -18,10 +18,9 @@ import lightpath.ui
 def lightrow(path):
     app = QApplication([])
     #Generate lightpath
-    w = lightpath.ui.LightRow(path.path[3], path)
+    w = lightpath.ui.LightRow(path.path[3])
     #Replace Update functions with mocks
     setattr(w.state_label, 'setText', Mock())
-    #setattr(w.indicator, 'update', Mock())
     return w
 
 def test_widget_updates(lightrow):

--- a/lightpath/ui/gui.py
+++ b/lightpath/ui/gui.py
@@ -82,7 +82,7 @@ class LightApp(Display):
         #Select the beamline to begin with
         beamline = beamline or self.destinations()[0]
         try:
-            idx = self.destinations().index(beamline)
+            idx = self.destinations().index(beamline.upper())
         except ValueError:
             logger.error("%s is not a valid beamline", beamline)
             idx = 0
@@ -262,6 +262,8 @@ class LightApp(Display):
                 else:
                     self.lightLayout.addWidget(widget, i, j)
         #Initialize interface
+        for row in self.device_rows:
+            row.update_state()
         self.update_path()
         self.update_mps()
 

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -108,11 +108,13 @@ class LightRow(InactiveRow):
         self.remove_button.setFont(self.font)
         #Subscribe device to state changes
         try:
+            #Wait for later to update widget
             self.device.subscribe(self.update_state,
                                   event_type=self.device.SUB_STATE,
-                                  run=True)
+                                  run=False)
         except:
-            logger.error("Unable to subscribe to device %s", device.name)
+            logger.error("Widget is unable to subscribe to device %s",
+                         device.name)
 
     def update_state(self, *args, **kwargs):
         """

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -107,9 +107,12 @@ class LightRow(InactiveRow):
         self.remove_button = QPushButton('Remove', parent=parent)
         self.remove_button.setFont(self.font)
         #Subscribe device to state changes
-        self.device.subscribe(self.update_state,
-                              event_type=self.device.SUB_STATE,
-                              run=True)
+        try:
+            self.device.subscribe(self.update_state,
+                                  event_type=self.device.SUB_STATE,
+                                  run=True)
+        except:
+            logger.error("Unable to subscribe to device %s", device.name)
 
     def update_state(self, *args, **kwargs):
         """

--- a/lightpath/ui/widgets.py
+++ b/lightpath/ui/widgets.py
@@ -76,7 +76,6 @@ class InactiveRow:
                 self.spacer,
                 self.state_label]
 
-
     def clear_sub(self):
         """
         Implemented by rows that have subscriptions
@@ -102,52 +101,15 @@ class LightRow(InactiveRow):
 
     parent : QObject, optional
     """
-    def __init__(self, device, path, parent=None):
+    def __init__(self, device, parent=None):
         super().__init__(device, parent=parent)
-        self.path   = path
         #Create PushButton
         self.remove_button = QPushButton('Remove', parent=parent)
         self.remove_button.setFont(self.font)
-        #Run once for correct state initialization
-        self.update_state()
-        self.update_mps()
-        self.update_path()
         #Subscribe device to state changes
-        self.path.subscribe(self.update_path, run=False)
-        self.device.subscribe(self.update_state, run=False)
-        self.path.subscribe(self.update_mps,
-                            event_type=path.SUB_MPSPATH_CHNG,
-                            run=False)
-
-    def update_path(self, *args,  **kwargs):
-        """
-        Update the PyDMRectangle to show the device as in the beam or not
-        """
-        #If our device is before or at the impediment, it is lit
-        if not self.path.impediment or (self.device.z
-                                        <= self.path.impediment.z):
-            self.indicator._default_color = Qt.cyan
-        #Otherwise, it is off
-        else:
-            self.indicator._default_color = Qt.gray
-        #Update widget display
-        self.indicator.update()
-
-    def update_mps(self, *args, **kwargs):
-        """
-        Update the MPS status of the frame
-
-        The frame of the row will be red if the device is tripping the beam,
-        yellow if it is faulted but a full trip is being prevented by an
-        upstream device
-        """
-        if self.device in self.path.tripped_devices:
-            self.frame.setStyleSheet("#name_frame {border: 2px solid red}")
-        elif self.device in self.path.faulted_devices:
-            self.frame.setStyleSheet("#name_frame {border: 2px "\
-                                     "solid rgb(255,215,0)}")
-        else:
-            self.frame.setStyleSheet("#frame {border: 0px solid black}")
+        self.device.subscribe(self.update_state,
+                              event_type=self.device.SUB_STATE,
+                              run=True)
 
     def update_state(self, *args, **kwargs):
         """
@@ -171,6 +133,8 @@ class LightRow(InactiveRow):
         #Set the color of the label
         if state == states.Removed.value:
             self.state_label.setStyleSheet("QLabel {color : rgb(124,252,0)}")
+        elif state == states.Unknown.value:
+            self.state_label.setStyleSheet("QLabel {color : rgb(255, 215, 0)}")
         else:
             self.state_label.setStyleSheet("QLabel {color : red}")
         #Disable the button
@@ -204,5 +168,3 @@ class LightRow(InactiveRow):
         Clear the subscription event
         """
         self.device.clear_sub(self.update_state)
-        self.path.clear_sub(self.update_mps)
-        self.path.clear_sub(self.update_path)


### PR DESCRIPTION
## Motivation
Closes #23 and closes #26 

EPICS calls are a resource! The`lightpath` shouldn't have blind trust that calls like `inserted` are implemented efficiently for each device. The UI should also be efficient using a single callback from the `BeamPath` object to configure all of the widgets instead of repeated calls. Here are a list of changes

## Change List
* `Unknown` is now displayed in yellow as not to be confused with `Inserted`. This is the only change to the UI
* All properties in `BeamPath` that make calls to `inserted` internally stash device positions. The idea is we should never be doing something like this which calls `device.inserted` for every device every time the property `inserted_devices` is requested.
```
if self.inserted_devices:
      return self.inserted_devices[0]
else:
      if self.inserted_devices > 5:
            return self.inserted_devices[:5]
```
Thinks weren't this obvious, but since calls like `impediment`, `blocking_devices` all made calls to `device.inserted` we were far from efficient
* `BeamPath` will only run subscriptions if a device is changed upstream of the `impediment`. We do not care if the 12th device changes state if the path is blocked at the first
* `BeamPath` uses the devices `SUB_STATE` event_type per https://github.com/slaclab/pcds-devices/pull/89
* `BeamPath` does not subscribe to child devices unless someone else subscribes to it
* Each `LightWidget` was subscribed to `BeamPath`. Each callback referenced `incident_devices`, this mean that when the `BeamPath` updated we called `incident_devices` * number of devices. This was a HUGE waste of time. Now ALL `BeamPath` callbacks are done once, changes are then propagated down to update the appropriate widgets. The individual widget still subscribes to its own device to reflect changes in device state.
* Cleaned up a few logging messages
