### PR TITLE
ENH: UI Improvements 

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+<!--
+## Screenshots (if appropriate):
+-->

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - source activate test-environment
   - pip install codecov
   - pip install -r requirements.txt
+  - pip install pyqtgraph
   #Install
   - python setup.py install
   - conda list # for DEBUG of QT issues

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -54,20 +54,24 @@ class LightController:
                              ', '.join(branch.branches), branch.name)
                 for dest in branch.branches:
                     if dest != bp.name:
-                        #If this is a branch that can pass beam through
-                        #without renaming the beamline split
-                        if branch.beamline in branch.branches: 
-                            section, after = bp.split(device=branch)
-                        else:
-                            section = bp
                         #Join with downstream path
                         logger.debug("Joining %s and %s", bp.name, dest)
                         try:
-                            self.beamlines[dest] = self.beamlines[dest].join(
-                                                                        section)
+                            downstream = self.beamlines[dest] 
+                            #self.beamlines[dest] = self.beamlines[dest].join(
+                            #                                            section)
                         except KeyError:
                             logger.critical("Device %s has invalid branching "
                                             "dest %s", branch.name, dest)
+                        else:
+                            #If this is a branch that can pass beam through
+                            #without renaming the beamline split
+                            if branch.beamline in branch.branches: 
+                                section,after=bp.split(z=downstream.path[0].z)
+                            else:
+                                section = bp
+                            self.beamlines[dest] = BeamPath.join(section,
+                                                                 downstream)
             #Set as attribute for easy access
             setattr(self, bp.name.replace(' ','_').lower(),
                     self.beamlines[bp.name])

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -24,13 +24,22 @@ def test_app_buttons(app, lcls, containers):
     #Check we initialized correctly
     assert lightapp.upstream()
     assert not lightapp.mps_only()
-    #Try to change display
+    #Create widgets
     assert len(lightapp.select_devices('MEC')) == 11
+    #Setup new display
+    mec_idx = lightapp.destination_combo.findText('MEC')
+    lightapp.destination_combo.setCurrentIndex(mec_idx)
+    lightapp.change_path_display()
+    assert len(lightapp.rows) == 11
 
-def test_remove_button(app, lcls, containers):
+def test_beampath_controls(app, lcls, containers):
     lightapp = LightApp(*lcls, containers=containers)
     lightapp.remove(True, device=lightapp.rows[0].device)
     assert lightapp.rows[0].device.removed
+    lightapp.insert(True, device=lightapp.rows[0].device)
+    assert lightapp.rows[0].device.inserted
+    lightapp.transmission_adjusted(50)
+    assert lightapp.path.minimum_transmission == 0.5
 
 @using_fake_epics_pv
 @pytest.mark.xfail

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>625</width>
+    <width>700</width>
     <height>472</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -24,7 +24,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>590</width>
+    <width>10000</width>
     <height>16777215</height>
    </size>
   </property>
@@ -43,23 +43,23 @@
      <item>
       <layout class="QHBoxLayout" name="header_layout">
        <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>5</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="button_layout">
-         <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>5</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
          <item>
           <widget class="QLabel" name="combo_label">
            <property name="sizePolicy">
@@ -81,30 +81,21 @@
           </widget>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_2"/>
-         </item>
-         <item>
           <widget class="QComboBox" name="destination_combo"/>
          </item>
          <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::MinimumExpanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <layout class="QVBoxLayout" name="check_layout">
-           <item>
+          <layout class="QGridLayout" name="gridLayout">
+           <item row="2" column="1">
+            <widget class="QCheckBox" name="mps_only_check">
+             <property name="text">
+              <string>Only show MPS devices</string>
+             </property>
+             <property name="autoRepeatInterval">
+              <number>96</number>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
             <widget class="QCheckBox" name="upstream_check">
              <property name="enabled">
               <bool>true</bool>
@@ -120,15 +111,80 @@
              </property>
             </widget>
            </item>
-           <item>
-            <widget class="QCheckBox" name="mps_only_check">
-             <property name="text">
-              <string>Only show MPS devices</string>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
              </property>
-             <property name="autoRepeatInterval">
-              <number>96</number>
+             <property name="text">
+              <string>Minimum Transmission</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
              </property>
             </widget>
+           </item>
+           <item row="2" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QLabel" name="label_2">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>1</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSlider" name="transmission_slider">
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>100</number>
+               </property>
+               <property name="value">
+                <number>80</number>
+               </property>
+               <property name="tracking">
+                <bool>false</bool>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="invertedAppearance">
+                <bool>false</bool>
+               </property>
+               <property name="invertedControls">
+                <bool>false</bool>
+               </property>
+               <property name="tickPosition">
+                <enum>QSlider::TicksAbove</enum>
+               </property>
+               <property name="tickInterval">
+                <number>20</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_3">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>100</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </item>
@@ -140,7 +196,7 @@
           <enum>Qt::Horizontal</enum>
          </property>
          <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
+          <enum>QSizePolicy::Expanding</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -152,19 +208,27 @@
        </item>
       </layout>
      </item>
-     <item alignment="Qt::AlignHCenter">
+     <item>
       <widget class="QScrollArea" name="scroll">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-         <horstretch>0</horstretch>
+         <horstretch>10</horstretch>
          <verstretch>10</verstretch>
         </sizepolicy>
        </property>
        <property name="minimumSize">
         <size>
-         <width>575</width>
+         <width>0</width>
          <height>0</height>
         </size>
+       </property>
+       <property name="font">
+        <font>
+         <kerning>false</kerning>
+        </font>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
        </property>
        <property name="autoFillBackground">
         <bool>false</bool>
@@ -179,7 +243,7 @@
         <enum>Qt::ScrollBarAlwaysOn</enum>
        </property>
        <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOn</enum>
+        <enum>Qt::ScrollBarAsNeeded</enum>
        </property>
        <property name="sizeAdjustPolicy">
         <enum>QAbstractScrollArea::AdjustToContents</enum>
@@ -192,12 +256,12 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>559</width>
-          <height>370</height>
+          <width>664</width>
+          <height>384</height>
          </rect>
         </property>
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>


### PR DESCRIPTION
## Description
Add a number of nice features to the user interface including:

* Remove buttons will not be displayed for devices that do not have a `remove` method
* Insert buttons are displayed for devices that have an `insert` method
* Instead of using a frame around the device name, the frame of the `LightIndicator` is used to display MPS faults
* A slider at the top of the window to control the `minimum_transmission` considered non-blocking
* A `try` `except` in `BeamPath.blocking_devices` will catch any errors raised while checking `inserted` or `removed` on devices. 

One note, @hhslepicka after https://github.com/slaclab/pydm/pull/164 `pyqtgraph` is now an explicit dependency (If you import `pydm` you need `pyqtgraph`). I know the `PyQt` req stuff can be tricky, but I don't think there is any harm in `pip` installing `pyqtgraph` even if you have installed `PyQt` via conda? For now I added this into our Travis, but something to think about.

Also added templates for new issues and PRs.

## Motivation
Closes #16 
Closes #22 
Closes #28 

## How Has This Been Tested?
Added tests for insert buttons, minimum_transmission slider as well as more strenuous tests for device loading
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Docstrings have been updated

## Screenshots
<img width="627" alt="screen shot 2017-11-04 at 7 46 32 pm" src="https://user-images.githubusercontent.com/25753048/32411524-37280330-c19a-11e7-9432-24573e4a1743.png">
