### PR TITLE
DEP: No more numpy dependency

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,6 @@ requirements:
       - ophyd
       - pydm
       - pyqt >=5 
-      - numpy
       - prettytable
 
 test:

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -16,13 +16,13 @@ affecting the beam.
 ####################
 # Standard Library #
 ####################
+import math
 import logging
 from collections import Iterable
 
 ####################
 #    Third Party   #
 ####################
-import numpy as np
 from prettytable    import PrettyTable
 from ophyd.ophydobj import OphydObject
 from ophyd.status   import wait as status_wait
@@ -84,7 +84,7 @@ class BeamPath(OphydObject):
             #Check types and positions
             for dev in self.path:
                 #Ensure positioning is physical
-                if np.isnan(dev.z) or dev.z < 0.:
+                if math.isnan(dev.z) or dev.z < 0.:
                     raise CoordinateError('Device %r is reporting a '
                                           'non-existant beamline position, '
                                           'its coordinate was not properly '
@@ -441,7 +441,7 @@ class BeamPath(OphydObject):
         if block:
             block = block.z
         else:
-            block = np.inf
+            block = math.inf
         #If device is upstream of impediment
         if obj and obj.z <= block:
             self._run_subs(sub_type = self.SUB_PTH_CHNG,

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -9,7 +9,6 @@ from enum import Enum
 ###############
 import happi
 import pytest
-import numpy as np
 from ophyd.device import Device
 from ophyd.status import DeviceStatus
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-numpy
 prettytable
 git+https://github.com/NSLS-II/ophyd
 git+https://github.com/slaclab/pydm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Remove numpy from the dependency tree. Only using it for `np.nan` and `np.inf` which are now included in the `math` module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Why not?
