### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable -c skywalker-dev -c conda-forge -c lightsource2-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c skywalker-dev -c pydm-dev -c conda-forge -c lightsource2-tag
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c skywalker-dev -c pydm-dev -c conda-forge -c lightsource2-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c skywalker-dev -c pydm-dev -c gsecars -c conda-forge -c lightsource2-tag
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov


### PR DESCRIPTION
Fix Travis bug with Numpy from pip missing openblas library.

## Description
Changed to install `pydm` from the proper anaconda channel (pydm-dev).
Added `-c gsecars` as `pydm` depends on `pyepics >=3.2.7` and gsecars is needed to satisfy this dependency.

## Motivation and Context
This change is required so we can properly build Lightpath.

## How Has This Been Tested?
At my environment & Travis.

## Where Has This Been Documented?
In here.
