### PR TITLE
Fix travis #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ install:
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov
-  - pip install -r requirements.txt --ignore-installed
-  - pip install pyqtgraph
+  #- pip install -r requirements.txt --ignore-installed
   #Install
   - python setup.py install
   - conda list # for DEBUG of QT issues
@@ -72,6 +71,6 @@ after_success:
       conda build . -c conda-forge -c skywalker-dev -c gsecars -c lightsource2-tag -c pydm-dev --token $CONDA_UPLOAD_TOKEN_TAG --python $TRAVIS_PYTHON_VERSION
     fi
   - |
-    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
       conda build . -c conda-forge -c skywalker-dev -c gsecars -c lightsource2-tag -c pydm-dev --token $CONDA_UPLOAD_TOKEN_DEV --python $TRAVIS_PYTHON_VERSION
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov
-  #- pip install -r requirements.txt --ignore-installed
   #Install
   - python setup.py install
   - conda list # for DEBUG of QT issues
@@ -71,6 +70,6 @@ after_success:
       conda build . -c conda-forge -c skywalker-dev -c gsecars -c lightsource2-tag -c pydm-dev --token $CONDA_UPLOAD_TOKEN_TAG --python $TRAVIS_PYTHON_VERSION
     fi
   - |
-    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $CONDA_UPLOAD_TOKEN_DEV != '' ]]; then
       conda build . -c conda-forge -c skywalker-dev -c gsecars -c lightsource2-tag -c pydm-dev --token $CONDA_UPLOAD_TOKEN_DEV --python $TRAVIS_PYTHON_VERSION
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c skywalker-dev -c pydm-dev -c gsecars -c conda-forge -c lightsource2-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pcds-devices pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c skywalker-dev -c pydm-dev -c gsecars -c conda-forge -c lightsource2-tag
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov


### PR DESCRIPTION
Fix Travis bug with Numpy from pip missing openblas library.

## Description
The previous fix ( PR #37 ) did not fixed the issue.
Looking at the TravisCI log I noticed that we had duplicated packages showing as `conda` installed and `pip` installed.
Since all the dependencies (except QDarkStyleSheet which is optional) are set at `conda create` there is no need to call `pip install -r requirements.txt` at travis.yml.
 
## Motivation and Context
This change is required so we can properly build Lightpath.

## How Has This Been Tested?
At my environment & Travis (https://travis-ci.org/hhslepicka/lightpath/jobs/302070533).

## Where Has This Been Documented?
In here.