### PR TITLE
FIX: Correctly specify happi version

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     run:
       - python {{PY_VER}}*,>=3
       - ophyd
-      - happi=0.5.0
+      - happi==v0.5.0
       - pydm
       - pyqt >=5 
       - prettytable


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Conda recipe does not correctly specify `happi` version

