### PR TITLE
MAINT: Update to latest pcdsdevices, happi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi=0.5.0 pcds-devices pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c skywalker-tag -c pydm-dev -c gsecars -c conda-forge -c lightsource2-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pcdsdevices pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c pcds-tag -c pydm-dev -c gsecars -c conda-forge -c lightsource2-tag
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pcdsdevices pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c pcds-tag -c pydm-dev -c gsecars -c conda-forge -c lightsource2-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig happi pyqt=5 coverage pip jinja2 wheel ophyd pytest prettytable pydm -c pcds-tag -c pydm-dev -c gsecars -c conda-forge -c lightsource2-tag
   #Launch Conda environment
   - source activate test-environment
   - pip install codecov

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     run:
       - python {{PY_VER}}*,>=3
       - ophyd
-      - happi <=0.5.0
+      - happi
       - pydm
       - pyqt >=5 
       - prettytable

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -24,12 +24,11 @@ logging.basicConfig(level='DEBUG')
 def main():
     #Gather devices
     lcls = lightpath.tests.lcls()
-    cntrs = lightpath.tests.containers()
     [dev.insert() for dev in lcls]
     #Create Application
     app   = pydm.PyQt.QtGui.QApplication([])
     #Create Lightpath
-    light = LightApp(*lcls, containers=cntrs)
+    light = LightApp(*lcls)
     light.show()
     #Execute 
     app.exec_()

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -39,20 +39,20 @@ class LightController:
     def __init__(self, *devices):
         #Create segmented beampaths beamlines
         self.beamlines = dict((line, BeamPath(*[dev for dev in devices
-                                                if dev.beamline == line],
+                                                if dev.md.beamline == line],
                                                 name=line))
-                              for line in set(d.beamline for d in devices))
+                              for line in set(d.md.beamline for d in devices))
 
         #Iterate through creating complete paths 
         for bp in sorted(self.beamlines.values(),
-                         key = lambda x : x.path[0].z):
+                         key = lambda x : x.path[0].md.z):
             logger.info("Assembling beamline %s ...", bp.name)
 
             #Grab branches off the beamline
             for branch in bp.branches:
                 logger.debug("Found branches onto beamlines %s from %s",
-                             ', '.join(branch.branches), branch.name)
-                for dest in branch.branches:
+                             ', '.join(branch.md.branches), branch.name)
+                for dest in branch.md.branches:
                     if dest != bp.name:
                         #Join with downstream path
                         logger.debug("Joining %s and %s", bp.name, dest)
@@ -66,8 +66,8 @@ class LightController:
                         else:
                             #If this is a branch that can pass beam through
                             #without renaming the beamline split
-                            if branch.beamline in branch.branches: 
-                                section,after=bp.split(z=downstream.path[0].z)
+                            if branch.md.beamline in branch.md.branches: 
+                                section,after=bp.split(z=downstream.path[0].md.z)
                             else:
                                 section = bp
                             self.beamlines[dest] = BeamPath.join(section,
@@ -135,9 +135,9 @@ class LightController:
             Path to and including given device
         """
         try:
-            prior, after = self.beamlines[device.beamline].split(device=device)
+            prior, after = self.beamlines[device.md.beamline].split(device=device)
 
         except KeyError:
-            raise ValueError("Beamline {} not found".format(device.beamline))
+            raise ValueError("Beamline {} not found".format(device.md.beamline))
 
         return prior

--- a/lightpath/controller.py
+++ b/lightpath/controller.py
@@ -84,17 +84,6 @@ class LightController:
         return list(set([p.impediment for p in self.beamlines.values()
                          if p.impediment and p.impediment not in p.branches]))
 
-    @property
-    def tripped_devices(self):
-        """
-        List of all tripped MPS devices in LCLS
-        """
-        devices = list()
-
-        for line in self.beamlines.values():
-            devices.extend(line.tripped_devices)
-
-        return list(set(devices))
 
     @property
     def devices(self):

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -84,7 +84,7 @@ class BeamPath(OphydObject):
             #Check types and positions
             for dev in self.path:
                 #Ensure positioning is physical
-                if math.isnan(dev.z) or dev.z < 0.:
+                if math.isnan(dev.md.z) or dev.md.z < 0.:
                     raise CoordinateError('Device %r is reporting a '
                                           'non-existant beamline position, '
                                           'its coordinate was not properly '
@@ -102,21 +102,21 @@ class BeamPath(OphydObject):
         """
         Branching devices along the path
         """
-        return [d for d in self.devices if getattr(d, 'branches', False)]
+        return [d for d in self.devices if getattr(d.md, 'branches', False)]
 
     @property
     def range(self):
         """
         Starting z position of beamline
         """
-        return self.path[0].z, self.path[-1].z
+        return self.path[0].md.z, self.path[-1].md.z
 
     @property
     def path(self):
         """
         List of devices ordered by coordinates
         """
-        return sorted(self.devices, key=lambda dev : dev.z)
+        return sorted(self.devices, key=lambda dev : dev.md.z)
 
     @property
     def blocking_devices(self):
@@ -131,10 +131,10 @@ class BeamPath(OphydObject):
         block         = list()
         for device in self.path:
             #If we have switched beamlines
-            if prior and device.beamline != prior.beamline:
+            if prior and device.md.beamline != prior.md.beamline:
                 #Find improperly configured optics
                 for optic in last_branches:
-                    if device.beamline not in optic.destination:
+                    if device.md.beamline not in optic.destination:
                         block.append(optic)
                 #Clear optics that have been evaluated
                 last_branches.clear()
@@ -142,8 +142,8 @@ class BeamPath(OphydObject):
             #If our last device was an optic, make sure it wasn't required
             #to continue along this beampath
             elif (prior in last_branches
-                and device.beamline in prior.branches
-                and device.beamline not in prior.destination):
+                and device.md.beamline in prior.md.branches
+                and device.md.beamline not in prior.destination):
                 block.append(last_branches.pop(-1))
 
             #Find branching devices and store
@@ -183,7 +183,7 @@ class BeamPath(OphydObject):
         if not impediment:
             return inserted
         #Otherwise only return upstream of the impediment
-        return [d for d in inserted if d.z <= impediment.z]
+        return [d for d in inserted if d.md.z <= impediment.md.z]
 
     def show_devices(self, file=None):
         """
@@ -203,7 +203,7 @@ class BeamPath(OphydObject):
         pt.float_format  = '8.5'
         #Add info
         for d in self.path:
-            pt.add_row([d.name, d.prefix, d.z, d.beamline, str(d.removed)])
+            pt.add_row([d.name, d.prefix, d.md.z, d.md.beamline, str(d.removed)])
         #Show table
         print(pt, file=file)
 
@@ -227,7 +227,7 @@ class BeamPath(OphydObject):
             return self.faulted_devices
 
         return [d for d in self.faulted_devices
-                  if ins_veto[0].z > d.z]
+                  if ins_veto[0].md.z > d.md.z]
 
     @property
     def faulted_devices(self):
@@ -354,14 +354,14 @@ class BeamPath(OphydObject):
             raise ValueError("Must supply information where to split the path")
         #Grab the z if given a device
         if device:
-            z = device.z
+            z = device.md.z
         #Look within range
         if z<self.range[0] or z>self.range[1]:
             raise ValueError("Split position {} is not within the range of "
                              "the path.".format(z))
         #Split the paths
-        return (BeamPath(*[d for d in self.devices if d.z <= z]),
-                BeamPath(*[d for d in self.devices if d.z >  z])
+        return (BeamPath(*[d for d in self.devices if d.md.z <= z]),
+                BeamPath(*[d for d in self.devices if d.md.z >  z])
                )
 
     @classmethod
@@ -439,11 +439,11 @@ class BeamPath(OphydObject):
         #Determine whether our path has been changed
         block = self.impediment
         if block:
-            block = block.z
+            block = block.md.z
         else:
             block = math.inf
         #If device is upstream of impediment
-        if obj and obj.z <= block:
+        if obj and obj.md.z <= block:
             self._run_subs(sub_type = self.SUB_PTH_CHNG,
                              device = obj)
         #Alert that an MPS system has moved

--- a/lightpath/path.py
+++ b/lightpath/path.py
@@ -68,7 +68,6 @@ class BeamPath(OphydObject):
     """
     #Subscription Information
     SUB_PTH_CHNG     = 'beampath_changed'
-    SUB_MPSPATH_CHNG = 'mpspath_changed'
     _default_sub     = SUB_PTH_CHNG
     #Transmission setting
     minimum_transmission = 0.1
@@ -206,39 +205,6 @@ class BeamPath(OphydObject):
             pt.add_row([d.name, d.prefix, d.md.z, d.md.beamline, str(d.removed)])
         #Show table
         print(pt, file=file)
-
-    @property
-    def veto_devices(self):
-        """
-        A list of MPS veto devices along the path
-        """
-        return [device for device in self.path
-                if getattr(device, 'mps', None)
-                and device.mps.veto_capable]
-
-    @property
-    def tripped_devices(self):
-        """
-        Devices who are both faulted and unprotected from the beam
-        """
-        ins_veto = [veto for veto in self.veto_devices if veto.inserted]
-
-        if not ins_veto:
-            return self.faulted_devices
-
-        return [d for d in self.faulted_devices
-                  if ins_veto[0].md.z > d.md.z]
-
-    @property
-    def faulted_devices(self):
-        """
-        A list of faulted MPS devices, this includes those protected by veto
-        devices
-        """
-        return [device for device in self.path
-                if getattr(device, 'mps', None)
-                and device.mps.faulted
-                and not (device.mps.bypassed or device.mps.veto_capable)]
 
     @property
     def impediment(self):
@@ -446,10 +412,6 @@ class BeamPath(OphydObject):
         if obj and obj.md.z <= block:
             self._run_subs(sub_type = self.SUB_PTH_CHNG,
                              device = obj)
-        #Alert that an MPS system has moved
-        if obj and getattr(obj, 'mps', None):
-            self._run_subs(sub_type=self.SUB_MPSPATH_CHNG,
-                           device=obj)
 
     def subscribe(self, cb, event_type=None, run=True):
         """

--- a/lightpath/tests/__init__.py
+++ b/lightpath/tests/__init__.py
@@ -1,1 +1,1 @@
-from .conftest import path, lcls, containers
+from .conftest import path, lcls

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -3,6 +3,7 @@
 ############
 import logging
 from enum import Enum
+from types import SimpleNamespace
 
 ###############
 # Third Party #
@@ -25,7 +26,7 @@ from lightpath import BeamPath
 def pytest_addoption(parser):
     parser.addoption("--log", action="store", default="INFO",
                      help="Set the level of the log")
-    parser.addoption("--logfile", action="store", default=None,
+    parser.addoption("--logfile", action="store", default='log',
                      help="Write the log output to specified file path")
 
 #Create a fixture to automatically instantiate logging setup
@@ -69,8 +70,9 @@ class Valve(Device):
 
     def __init__(self, name, z, beamline):
         super().__init__(name, name=name)
-        self.z    = z
-        self.beamline     = beamline
+        self.md = SimpleNamespace()
+        self.md.z    = z
+        self.md.beamline     = beamline
         self.status = Status.removed
         self.mps    = MPS(self)
 
@@ -150,8 +152,8 @@ class Crystal(Valve):
     def __init__(self, name, z, beamline, states):
         super().__init__(name, z, beamline)
         self.states = states
-        self.branches = [dest for state in self.states
-                              for dest  in state]
+        self.md.branches = [dest for state in self.states
+                            for dest  in state]
         self.mps      = None
 
     @property

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -257,12 +257,3 @@ def lcls():
             IPIMB('XCS IPM',       z=21.,  beamline='XCS'),
             Valve('XCS Valve',     z=22.,  beamline='XCS'),
               ]
-
-@pytest.fixture(scope='function')
-def containers():
-    return [happi.Device(name='FEE Valve 3', prefix='TST:FEE:VGC:03',
-                         beamline='HXR', z=10.0),
-            happi.Device(name='XC2 Valve 2', prefix='TST:XCS:VGC:02',
-                         beamline='XCS', z=23.0),
-           ]
-

--- a/lightpath/tests/conftest.py
+++ b/lightpath/tests/conftest.py
@@ -74,7 +74,6 @@ class Valve(Device):
         self.md.z    = z
         self.md.beamline     = beamline
         self.status = Status.removed
-        self.mps    = MPS(self)
 
 
     @property
@@ -109,9 +108,6 @@ class Valve(Device):
         self.status = Status.inserted
         #Run subscriptions to device state
         self._run_subs(obj=self, sub_type=self._default_sub)
-        #Run subscriptions to mps state
-        if self.mps:
-            self.mps._run_subs(obj=self, sub_type=self.mps._default_sub)
         #Return complete status object
         return DeviceStatus(self, done=True, success=True)
 
@@ -124,9 +120,6 @@ class Valve(Device):
         self.status = Status.removed
         #Run subscriptions to device state
         self._run_subs(obj=self, sub_type=self._default_sub)
-        #Run subscriptions to mps state
-        if self.mps:
-            self.mps._run_subs(obj=self, sub_type=self.mps._default_sub)
         #Return complete status object
         return DeviceStatus(self, done=True, success=True)
 
@@ -154,7 +147,6 @@ class Crystal(Valve):
         self.states = states
         self.md.branches = [dest for state in self.states
                             for dest  in state]
-        self.mps      = None
 
     @property
     def destination(self):

--- a/lightpath/tests/test_controller.py
+++ b/lightpath/tests/test_controller.py
@@ -67,18 +67,6 @@ def test_controller_device_summaries(lcls):
     assert len(controller.incident_devices) == 1
     lcls[3].remove()
 
-    #No tripped devices
-    assert controller.tripped_devices == []
-    #Common tripped devices
-    lcls[0].insert()
-    assert controller.tripped_devices == [lcls[0]]
-    #Multiple faults
-    controller.cxi.path[8].insert()
-    assert len(controller.tripped_devices) == 2
-    controller.cxi.path[2].insert()
-    assert len(controller.tripped_devices) == 1
-
-
 def test_path_to(lcls):
     controller = LightController(*lcls)
     bp = controller.path_to(lcls[12])

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -7,7 +7,6 @@ import os.path
 # Third Party #
 ###############
 import pytest
-from pcdsdevices.sim.pv import using_fake_epics_pv
 
 ##########
 # Module #

--- a/lightpath/tests/test_gui.py
+++ b/lightpath/tests/test_gui.py
@@ -14,39 +14,23 @@ from pcdsdevices.sim.pv import using_fake_epics_pv
 ##########
 from lightpath.ui import LightApp
 
-def test_app_buttons(lcls, containers):
-    lightapp = LightApp(*lcls, containers=containers)
+def test_app_buttons(lcls):
+    lightapp = LightApp(*lcls)
     #Check we initialized correctly
     assert lightapp.upstream()
-    assert not lightapp.mps_only()
     #Create widgets
-    assert len(lightapp.select_devices('MEC')) == 11
+    assert len(lightapp.select_devices('MEC')) == 10
     #Setup new display
     mec_idx = lightapp.destination_combo.findText('MEC')
     lightapp.destination_combo.setCurrentIndex(mec_idx)
     lightapp.change_path_display()
-    assert len(lightapp.rows) == 11
+    assert len(lightapp.rows) == 10
 
-def test_beampath_controls(lcls, containers):
-    lightapp = LightApp(*lcls, containers=containers)
+def test_beampath_controls(lcls):
+    lightapp = LightApp(*lcls)
     lightapp.remove(True, device=lightapp.rows[0].device)
     assert lightapp.rows[0].device.removed
     lightapp.insert(True, device=lightapp.rows[0].device)
     assert lightapp.rows[0].device.inserted
     lightapp.transmission_adjusted(50)
     assert lightapp.path.minimum_transmission == 0.5
-
-@using_fake_epics_pv
-@pytest.mark.xfail
-def test_app_from_json():
-    #Basic configuration
-    lit = LightApp.from_json(os.path.join(
-                             os.path.dirname(os.path.abspath(__file__)),
-                             'path.json'))
-    assert len(lit.light.devices) == 16
-    #Limit device search
-    lit = LightApp.from_json(os.path.join(
-                             os.path.dirname(os.path.abspath(__file__)),
-                             'path.json'),
-                             end=900.0)
-    assert len(lit.light.devices) == 9

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -25,7 +25,7 @@ def test_sort(path):
     for i,device in enumerate(path.path):
         try:
         #Each devices is before than the next
-            assert device.z < path.path[i+1].z
+            assert device.md.z < path.path[i+1].md.z
         #Except for the final device
         except IndexError:
             assert i == len(path.devices) - 1
@@ -159,8 +159,8 @@ def test_split(path):
     assert path.split(device=path.path[4])[1].path == second.path
     
     #Test split by z yields partial beampaths
-    assert path.split(z=path.path[4].z)[0].path == first.path
-    assert path.split(z=path.path[4].z)[1].path == second.path
+    assert path.split(z=path.path[4].md.z)[0].path == first.path
+    assert path.split(z=path.path[4].md.z)[1].path == second.path
 
 
 def test_callback(path):
@@ -200,7 +200,7 @@ def test_faulted_devices(path):
 
 def test_complex_branching(lcls):
     #Upstream Optic
-    xcs = [d for d in lcls if d.beamline in ['HXR','XCS']]
+    xcs = [d for d in lcls if d.md.beamline in ['HXR','XCS']]
     bp  = BeamPath(*xcs)
     #Remove all the devices
     for d in xcs : d.remove()
@@ -211,7 +211,7 @@ def test_complex_branching(lcls):
     #Path should be cleared
     assert bp.blocking_devices == []
     #Downstream Optic
-    mec = [d for d in lcls if d.beamline in ['HXR','MEC']]
+    mec = [d for d in lcls if d.md.beamline in ['HXR','MEC']]
     bp  = BeamPath(*mec)
     #Remove all devices
     for d in mec : d.remove()

--- a/lightpath/tests/test_path.py
+++ b/lightpath/tests/test_path.py
@@ -174,30 +174,6 @@ def test_callback(path):
     assert cb.called
 
 
-def test_veto_devices(path):
-    #Find the stopper correctly
-    assert path.veto_devices == [path.path[2]]
-
-
-def test_faulted_devices(path):
-    #No faulted devices by default
-    assert path.faulted_devices == []
-    #Insert a gate valve
-    path.path[0].insert()
-    assert path.faulted_devices == [path.path[0]]
-    #Bypass fault
-    path.path[0].mps.bypassed = True
-    assert path.faulted_devices == []
-    path.path[0].mps.bypassed = False
-    #Insert two gate valves
-    path.path[1].insert()
-    assert path.faulted_devices == [path.path[0], path.path[1]]
-    #Insert one more gatevalve past stopper
-    path.path[6].insert()
-    assert path.faulted_devices == [path.path[0],
-                                    path.path[1],
-                                    path.path[6]]
-
 def test_complex_branching(lcls):
     #Upstream Optic
     xcs = [d for d in lcls if d.md.beamline in ['HXR','XCS']]
@@ -227,18 +203,6 @@ def test_complex_branching(lcls):
     bp.path[4].remove()
     assert bp.blocking_devices == []
 
-def test_tripped_devices(path):
-    #No tripped devices by default
-    assert path.tripped_devices == []
-    #Insert a gate valve
-    path.path[0].insert()
-    assert path.tripped_devices == [path.path[0]]
-    #Insert two gate valves
-    path.path[6].insert()
-    assert path.tripped_devices == [path.path[0], path.path[6]]
-    #Insert stopper to halt downstream faults
-    path.path[2].insert()
-    assert path.tripped_devices == [path.path[0]]
 
 known_table = """\
 +-------+--------+----------+----------+---------+

--- a/lightpath/ui/lightapp.ui
+++ b/lightpath/ui/lightapp.ui
@@ -85,16 +85,6 @@
          </item>
          <item>
           <layout class="QGridLayout" name="gridLayout">
-           <item row="2" column="1">
-            <widget class="QCheckBox" name="mps_only_check">
-             <property name="text">
-              <string>Only show MPS devices</string>
-             </property>
-             <property name="autoRepeatInterval">
-              <number>96</number>
-             </property>
-            </widget>
-           </item>
            <item row="0" column="1">
             <widget class="QCheckBox" name="upstream_check">
              <property name="enabled">
@@ -257,7 +247,7 @@
           <x>0</x>
           <y>0</y>
           <width>664</width>
-          <height>384</height>
+          <height>386</height>
          </rect>
         </property>
         <property name="sizePolicy">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This pull request makes `lightpath` work with `happi > 0.5.x` and `pcdsdevices > 0.3.x`. The major changes that affected the lightpath were:

1. Metadata is no longer tacked on to the device. All references to `device.z` had to be changed to `device.md.z`
2. `MPS` devices are no longer associated with devices. They will be in the `happi` database as a separate object
3. All device loading should be done in happi.

For the actual `BeamPath` code, I deprecated all the references to the MPS system. In the future, we will just create a small object `MPSSummary` that manages the entire MPS system for a beamline. These will also be displayed in their own panel in the purpose of the GUI.

The most frustrating change is that the UI used to treat `happi.Device` objects and `pcdsdevices` objects the same. Now that the latter has metadata contained in the `md` attribute, that code does not work. For now I have just decided to remove them from the main lightpath GUI. I think the answer in the end is to have a separate panel where disconnected devices are displayed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should now be importable in newer releases of `pcds-envs`

In the end, this PR is a step back in terms of feature set but nothing that was heavily used was taken away. It can be used in the new `hutch-python` environment. The rest will be addressed during the UI re-release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Updated tests to match new library expectations. Also created a `BeamPath` in the current `mfxpython` environment to do a live check.